### PR TITLE
Fixed a typo in the BMP280 i2c addr constant (was BMP180)

### DIFF
--- a/bme280-bmp280/bme280.py
+++ b/bme280-bmp280/bme280.py
@@ -39,7 +39,7 @@ from array import array
 # BME280 default address (recently noticed that it was 0x77 instead of 0x76).
 BME280_I2CADDR = 0x77
 # BMP280 default address
-BMP180_I2CADDR = 0x77
+BMP280_I2CADDR = 0x77
 
 # Operating Modes
 BME280_OSAMPLE_1 = 1

--- a/bme280-bmp280/readme.md
+++ b/bme280-bmp280/readme.md
@@ -46,7 +46,7 @@ from machine import Pin, I2C
 from bme280 import *
 
 i2c = I2C(scl=Pin(5), sda=Pin(4))
-bmp = BME280(i2c=i2c, address=BMP180_I2CADDR )
+bmp = BME280(i2c=i2c, address=BMP280_I2CADDR )
 
 print(bmp.values)
 ```


### PR DESCRIPTION
Was about to import this library and found this small typo, nothing critical but here's a PR.

BTW many thanks for this library !